### PR TITLE
feat: 짐 순서 변경 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	runtimeOnly 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/packman/category/Category.java
+++ b/src/main/java/org/packman/category/Category.java
@@ -1,0 +1,20 @@
+package org.packman.category;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long packingListId;
+
+}

--- a/src/main/java/org/packman/pack/Pack.java
+++ b/src/main/java/org/packman/pack/Pack.java
@@ -1,0 +1,41 @@
+package org.packman.pack;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private Long categoryId;
+
+    private int position;
+
+    @Builder
+    private Pack(Long id, String name, Long categoryId, int position) {
+        this.id = id;
+        this.name = name;
+        this.categoryId = categoryId;
+        this.position = position;
+    }
+
+    public Pack updatePosition(Long categoryId, int position) {
+        return Pack.builder()
+                .id(this.id)
+                .name(this.name)
+                .categoryId(categoryId)
+                .position(position)
+                .build();
+    }
+}

--- a/src/main/java/org/packman/pack/PackController.java
+++ b/src/main/java/org/packman/pack/PackController.java
@@ -1,0 +1,24 @@
+package org.packman.pack;
+
+import org.packman.pack.dto.request.PackPosition;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/packs")
+public class PackController {
+
+    private final PackService packService;
+
+    private PackController(PackService packService) {
+        this.packService = packService;
+    }
+
+    @PatchMapping("/position")
+    public void updatePosition(@RequestBody PackPosition request) {
+        packService.updatePosition(request);
+    }
+
+}

--- a/src/main/java/org/packman/pack/PackRepository.java
+++ b/src/main/java/org/packman/pack/PackRepository.java
@@ -1,0 +1,9 @@
+package org.packman.pack;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PackRepository extends JpaRepository<Pack, Long> {
+
+}

--- a/src/main/java/org/packman/pack/PackService.java
+++ b/src/main/java/org/packman/pack/PackService.java
@@ -1,0 +1,26 @@
+package org.packman.pack;
+
+import org.packman.pack.dto.request.PackPosition;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PackService {
+
+    private final PackRepository packRepository;
+
+    private PackService(PackRepository packRepository) {
+        this.packRepository = packRepository;
+    }
+
+    public void updatePosition(PackPosition packPosition) {
+        Pack pack = packRepository.findById(packPosition.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 짐입니다."));
+
+        Pack updatePack = pack.updatePosition(
+                packPosition.getCategoryId(),
+                packPosition.getPosition()
+        );
+
+        packRepository.save(updatePack);
+    }
+}

--- a/src/main/java/org/packman/pack/dto/request/PackPosition.java
+++ b/src/main/java/org/packman/pack/dto/request/PackPosition.java
@@ -1,0 +1,22 @@
+package org.packman.pack.dto.request;
+
+public class PackPosition {
+
+    private Long id;
+
+    private Long categoryId;
+
+    private int position;
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+}

--- a/src/main/java/org/packman/packingList/PackingList.java
+++ b/src/main/java/org/packman/packingList/PackingList.java
@@ -1,0 +1,18 @@
+package org.packman.packingList;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PackingList {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,19 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
 
+  datasource:
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:tcp://localhost/~/packup
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
## ✅ 작업

짐 순서 변경과 관련된 짐 수정 API 구현

##  📝 구현 설명 및 결과

- 처음 짐 정보
<img width="530" alt="스크린샷 2024-02-26 오후 4 21 04" src="https://github.com/Team-Packman/New-Packman-Backend/assets/63945197/72a942ec-678a-4bcf-81de-da7d244f3cfa"> </br>

- API 실행
<img width="600" alt="스크린샷 2024-02-26 오후 4 21 28" src="https://github.com/Team-Packman/New-Packman-Backend/assets/63945197/51c2ce3b-7753-499c-8970-db94521ad517"> </br>

- 수정된 짐 정보
<img width="532" alt="스크린샷 2024-02-26 오후 4 21 41" src="https://github.com/Team-Packman/New-Packman-Backend/assets/63945197/fa0cfd92-daeb-4b8f-9b59-1e01c1742ffc"> </br>

짐 순서를 `potision` 컬럼으로 관리하여 사용자의 드래그 앤 드롭으로 짐 순서가 변경된 경우,
해당 짐의 **카테고리 id**와 **카테고리 내의 짐의 순서**를 받아서 변경하였다.

[구현 관련 기록](https://velog.io/@hyeonz/팩잉-Drag-Drop)

## 👋 마무리
- close #1 