### PR TITLE
feat: cors 설정

### DIFF
--- a/src/main/java/org/packman/PackmanApplication.java
+++ b/src/main/java/org/packman/PackmanApplication.java
@@ -2,12 +2,14 @@ package org.packman;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan(value = {"org.packman.config"})
 public class PackmanApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(PackmanApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(PackmanApplication.class, args);
+    }
 
 }

--- a/src/main/java/org/packman/config/CorsConfig.java
+++ b/src/main/java/org/packman/config/CorsConfig.java
@@ -1,0 +1,25 @@
+package org.packman.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Profile("develop")
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    private final WebProperties webProperties;
+
+    public CorsConfig(WebProperties webProperties) {
+        this.webProperties = webProperties;
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/v2/**")
+                .allowedOrigins(webProperties.allowedOrigins().toArray(String[]::new))
+                .allowedMethods("*")
+                .allowCredentials(true)
+                .maxAge(1800);
+    }
+}

--- a/src/main/java/org/packman/config/WebProperties.java
+++ b/src/main/java/org/packman/config/WebProperties.java
@@ -1,0 +1,10 @@
+package org.packman.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "web")
+public record WebProperties(List<String> allowedOrigins) {
+
+}


### PR DESCRIPTION
## ✅ 한 일 
- allowed-origins값을 yml파일을 통해 동적으로 불러올 수 있도록 구현
- cors설정

## 📝 구현 설명 및 결과

### yml파일에서 동적으로 허용할 출처 불러오기
```java
@ConfigurationProperties(prefix = "web")
``` 
.properties, .yml 파일에 있는 property를 자바 클래스에 값을 가져와서(바인딩) 사용할 수 있게 해주는 어노테이션을 사용하여 설정 파일에서 동적으로 허용 가능한 출처들을 불러올 수 있게 해주었다.

```java
@SpringBootApplication
@ConfigurationPropertiesScan(value = {"org.packman.config"})
public class PackmanApplication {...}
``` 
패키지를 기반으로 `@ConfigurationProperties`가 등록된 클래스들을 찾아 값들을 주입하고 빈으로 등록해주는 어노테이션을 붙어 구현하였다.

### Cors 설정
`WebMvcConfigurer`의 `addCorsMappings`메서드를 오버라이드하여 Cors 설정을 하였다.

[구현 관련 TIL](https://velog.io/@hyeonz/24.02.26)


## 😊 마무리
- close #3 