### PR TITLE
feat: 짐 순서 변경 API 추가 구현

### DIFF
--- a/src/main/java/org/packman/pack/Pack.java
+++ b/src/main/java/org/packman/pack/Pack.java
@@ -20,22 +20,47 @@ public class Pack {
 
     private Long categoryId;
 
-    private int position;
+    private Integer position;
 
     @Builder
-    private Pack(Long id, String name, Long categoryId, int position) {
+    private Pack(Long id, String name, Long categoryId, Integer position) {
         this.id = id;
         this.name = name;
         this.categoryId = categoryId;
         this.position = position;
     }
 
-    public Pack updatePosition(Long categoryId, int position) {
+    public Pack updatePositionAndCategory(Long categoryId, Integer position) {
         return Pack.builder()
                 .id(this.id)
                 .name(this.name)
                 .categoryId(categoryId)
                 .position(position)
                 .build();
+    }
+
+    public Pack updatePosition(Integer position) {
+        return Pack.builder()
+                .id(this.id)
+                .name(this.name)
+                .categoryId(this.categoryId)
+                .position(position)
+                .build();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public String getName() {
+        return name;
     }
 }

--- a/src/main/java/org/packman/pack/PackController.java
+++ b/src/main/java/org/packman/pack/PackController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/packs")
+@RequestMapping("/api/v2/packs")
 public class PackController {
 
     private final PackService packService;

--- a/src/main/java/org/packman/pack/PackRepository.java
+++ b/src/main/java/org/packman/pack/PackRepository.java
@@ -3,7 +3,11 @@ package org.packman.pack;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PackRepository extends JpaRepository<Pack, Long> {
+    List<Pack> findByCategoryIdAndPositionGreaterThan(Long categoryId, Integer position);
 
+    List<Pack> findByCategoryIdAndPositionGreaterThanEqual(Long categoryId, Integer position);
 }

--- a/src/main/java/org/packman/pack/PackService.java
+++ b/src/main/java/org/packman/pack/PackService.java
@@ -2,25 +2,70 @@ package org.packman.pack;
 
 import org.packman.pack.dto.request.PackPosition;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 public class PackService {
 
     private final PackRepository packRepository;
 
-    private PackService(PackRepository packRepository) {
+    public PackService(PackRepository packRepository) {
         this.packRepository = packRepository;
     }
 
+    @Transactional
     public void updatePosition(PackPosition packPosition) {
-        Pack pack = packRepository.findById(packPosition.getId())
+        Pack originalPack = packRepository.findById(packPosition.getId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 짐입니다."));
 
-        Pack updatePack = pack.updatePosition(
+        packOut(originalPack);
+
+        Pack updatePack = originalPack.updatePositionAndCategory(
                 packPosition.getCategoryId(),
                 packPosition.getPosition()
         );
 
-        packRepository.save(updatePack);
+        packIn(updatePack);
     }
+
+    public void packOut(Pack packBeforeMove) {
+        List<Pack> packs = packRepository.findByCategoryIdAndPositionGreaterThan(
+                packBeforeMove.getCategoryId(),
+                packBeforeMove.getPosition()
+        );
+
+        List<Pack> updatePacks = new ArrayList<>();
+
+        for (Pack pack : packs) {
+            Pack updatePack = pack.updatePosition(pack.getPosition() - 1);
+            updatePacks.add(updatePack);
+        }
+
+        Pack originalPack = packBeforeMove.updatePosition(null);
+        updatePacks.add(originalPack);
+
+        packRepository.saveAll(updatePacks);
+    }
+
+    private void packIn(Pack packAfterMove) {
+        List<Pack> packs = packRepository.findByCategoryIdAndPositionGreaterThanEqual(
+                packAfterMove.getCategoryId(),
+                packAfterMove.getPosition()
+        );
+
+        List<Pack> updatePacks = new ArrayList<>();
+
+        for (Pack pack : packs) {
+            Pack updatePack = pack.updatePosition(pack.getPosition() + 1);
+            updatePacks.add(updatePack);
+        }
+
+        updatePacks.add(packAfterMove);
+
+        packRepository.saveAll(updatePacks);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## ✅ 한 일  
- 짐 순서 변경 API 추가 구현

## 📝 구현 설명 및 결과

카테고리의 이동이 있을 수도 있으므로 짐이 드래그되는 경우, 드롭되는 경우를 나눠서 생각한 후 구현하였다.

<나가는 경우>

맨 앞: 뒤의 짐들 position - 1
중간: 뒤의 짐들 position - 1
마지막: 아무일도 일어나지 않음

<들어오는 경우>

맨 앞: 뒤의 짐들 position + 1
중간: 뒤의 짐들 position + 1
마지막: 아무일도 일어나지 않음

[구현관련 TIL](https://velog.io/@hyeonz/24.02.27)

## 😊 마무리
- close #5 