### PR TITLE
feat: 카테고리, 짐 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/packman/category/Category.java
+++ b/src/main/java/org/packman/category/Category.java
@@ -15,6 +15,15 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String name;
+
     private Long packingListId;
 
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/org/packman/category/CategoryController.java
+++ b/src/main/java/org/packman/category/CategoryController.java
@@ -1,0 +1,31 @@
+package org.packman.category;
+
+import org.packman.pack.Pack;
+import org.packman.pack.dto.response.PackGet;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    private CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    @GetMapping("/{categoryId}/packs")
+    public List<PackGet> get(@PathVariable Long categoryId) {
+        List<Pack> packs = categoryService.getPacks(categoryId);
+
+        return packs.stream()
+                .map(PackGet::from)
+                .toList();
+    }
+
+}

--- a/src/main/java/org/packman/category/CategoryRepository.java
+++ b/src/main/java/org/packman/category/CategoryRepository.java
@@ -1,0 +1,13 @@
+package org.packman.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    List<Category> findAllByPackingListId(Long packingListId);
+
+}

--- a/src/main/java/org/packman/category/CategoryService.java
+++ b/src/main/java/org/packman/category/CategoryService.java
@@ -13,12 +13,19 @@ public class CategoryService {
 
     private final PackService packService;
 
-    public CategoryService(PackService packService) {
+    private final CategoryRepository categoryRepository;
+
+    public CategoryService(PackService packService, CategoryRepository categoryRepository) {
         this.packService = packService;
+        this.categoryRepository = categoryRepository;
     }
 
     public List<Pack> getPacks(Long categoryId) {
         return packService.getPacksByCategoryId(categoryId);
+    }
+
+    public List<Category> getAllByPackingListId(Long id) {
+        return categoryRepository.findAllByPackingListId(id);
     }
 
 }

--- a/src/main/java/org/packman/category/CategoryService.java
+++ b/src/main/java/org/packman/category/CategoryService.java
@@ -1,0 +1,24 @@
+package org.packman.category;
+
+import org.packman.pack.Pack;
+import org.packman.pack.PackService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final PackService packService;
+
+    public CategoryService(PackService packService) {
+        this.packService = packService;
+    }
+
+    public List<Pack> getPacks(Long categoryId) {
+        return packService.getPacksByCategoryId(categoryId);
+    }
+
+}

--- a/src/main/java/org/packman/category/dto/response/CategoryGet.java
+++ b/src/main/java/org/packman/category/dto/response/CategoryGet.java
@@ -1,0 +1,9 @@
+package org.packman.category.dto.response;
+
+import org.packman.category.Category;
+
+public record CategoryGet(Long id, String name) {
+    public static CategoryGet from(Category category) {
+        return new CategoryGet(category.getId(), category.getName());
+    }
+}

--- a/src/main/java/org/packman/pack/PackRepository.java
+++ b/src/main/java/org/packman/pack/PackRepository.java
@@ -10,4 +10,6 @@ public interface PackRepository extends JpaRepository<Pack, Long> {
     List<Pack> findByCategoryIdAndPositionGreaterThan(Long categoryId, Integer position);
 
     List<Pack> findByCategoryIdAndPositionGreaterThanEqual(Long categoryId, Integer position);
+
+    List<Pack> findAllByCategoryIdOrderByPosition(Long categoryId);
 }

--- a/src/main/java/org/packman/pack/PackService.java
+++ b/src/main/java/org/packman/pack/PackService.java
@@ -68,4 +68,9 @@ public class PackService {
         packRepository.saveAll(updatePacks);
     }
 
+    @Transactional(readOnly = true)
+    public List<Pack> getPacksByCategoryId(Long categoryId) {
+        return packRepository.findAllByCategoryIdOrderByPosition(categoryId);
+    }
+
 }

--- a/src/main/java/org/packman/pack/dto/response/PackGet.java
+++ b/src/main/java/org/packman/pack/dto/response/PackGet.java
@@ -1,0 +1,9 @@
+package org.packman.pack.dto.response;
+
+import org.packman.pack.Pack;
+
+public record PackGet(Long id, String name) {
+    public static PackGet from(Pack pack) {
+        return new PackGet(pack.getId(), pack.getName());
+    }
+}

--- a/src/main/java/org/packman/packingList/PackingListController.java
+++ b/src/main/java/org/packman/packingList/PackingListController.java
@@ -1,0 +1,30 @@
+package org.packman.packingList;
+
+import org.packman.category.Category;
+import org.packman.category.dto.response.CategoryGet;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v2/packingLists")
+public class PackingListController {
+
+    private final PackingListService packingListService;
+
+    public PackingListController(PackingListService packingListService) {
+        this.packingListService = packingListService;
+    }
+
+    @GetMapping("/{packingLIstId}/categories")
+    public List<CategoryGet> get(@PathVariable Long packingLIstId) {
+        List<Category> categories = packingListService.getCategories(packingLIstId);
+
+        return categories.stream()
+                .map(CategoryGet::from)
+                .toList();
+    }
+}

--- a/src/main/java/org/packman/packingList/PackingListService.java
+++ b/src/main/java/org/packman/packingList/PackingListService.java
@@ -1,0 +1,23 @@
+package org.packman.packingList;
+
+import org.packman.category.Category;
+import org.packman.category.CategoryService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class PackingListService {
+
+    private final CategoryService categoryService;
+
+    public PackingListService(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
+
+    public List<Category> getCategories(Long packingListId) {
+        return categoryService.getAllByPackingListId(packingListId);
+    }
+}


### PR DESCRIPTION
## ✅ 한 일 
- 패킹리스트의 카테고리 목록 조회 API 구현
- 카테고리의 짐 목록 조회 API 구현

## 📝 구현 설명 및 결과

### 기존 구조에서 변화

기존: 패킹리스트와 관련된 모든 정보를 하나의 API로 호출
```java
{
    "id": "1",
    "folderId": "12",
    "inviteCode": "frggh",
    "isSaved": false
    "category": [
        {
            "id": "1",
            "name": "필수",
            "pack": [
                {
                    "id": "1",
                    "name": "여권",
                    "isChecked": true,
                    "packer": null
                }
            ]
        }
    ]
}
``` 

현재: 카테고리, 짐을 각각 조회하도록 2개의 API로 분리
- 카테고리 목록 조회
```java
[
    {
        "id": 1,
        "name": "카테고리1"
    },
    {
        "id": 2,
        "name": "카테고리2"
    }
]
``` 


- 짐 목록 조회
-
```java
[
    {
        "id": 1,
        "name": "짐6"
    },
    {
        "id": 2,
        "name": "짐7"
    }
]
``` 
현재는 간단한 버전이지만 점차 컬럼이 추가될 예정이다.

[구현관련 TIL](https://velog.io/@hyeonz/24.02.27)

## 😊 마무리
- close #7 