### PR TITLE
feat: 패킹리스트 순서 변경 API 구현

### DIFF
--- a/src/main/java/org/packman/packingList/PackingList.java
+++ b/src/main/java/org/packman/packingList/PackingList.java
@@ -5,6 +5,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
@@ -15,4 +16,39 @@ public class PackingList {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private Integer position;
+
+    private String title;
+
+    private Long userId;
+
+    @Builder
+    public PackingList(Long id, Integer position, String title, Long userId) {
+        this.id = id;
+        this.position = position;
+        this.title = title;
+        this.userId = userId;
+    }
+
+    public PackingList updatePosition(Integer position) {
+        return PackingList.builder()
+                .id(this.id)
+                .position(position)
+                .title(this.title)
+                .userId(this.userId)
+                .build();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Integer getPosition() {
+        return position;
+    }
+
+    public String getTitle() {
+        return title;
+    }
 }
+

--- a/src/main/java/org/packman/packingList/PackingListController.java
+++ b/src/main/java/org/packman/packingList/PackingListController.java
@@ -2,8 +2,11 @@ package org.packman.packingList;
 
 import org.packman.category.Category;
 import org.packman.category.dto.response.CategoryGet;
+import org.packman.packingList.request.PackingListPosition;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,9 +18,10 @@ public class PackingListController {
 
     private final PackingListService packingListService;
 
-    public PackingListController(PackingListService packingListService) {
+    private PackingListController(PackingListService packingListService) {
         this.packingListService = packingListService;
     }
+
 
     @GetMapping("/{packingLIstId}/categories")
     public List<CategoryGet> get(@PathVariable Long packingLIstId) {
@@ -27,4 +31,10 @@ public class PackingListController {
                 .map(CategoryGet::from)
                 .toList();
     }
+
+    @PatchMapping("/position")
+    public void updatePosition(@RequestBody PackingListPosition request) {
+        packingListService.updatePosition(request);
+    }
+
 }

--- a/src/main/java/org/packman/packingList/PackingListRepository.java
+++ b/src/main/java/org/packman/packingList/PackingListRepository.java
@@ -1,0 +1,13 @@
+package org.packman.packingList;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PackingListRepository extends JpaRepository<PackingList, Long> {
+    List<PackingList> findByPositionGreaterThan(Integer position);
+
+    List<PackingList> findByPositionGreaterThanEqual(Integer position);
+}

--- a/src/main/java/org/packman/packingList/PackingListService.java
+++ b/src/main/java/org/packman/packingList/PackingListService.java
@@ -2,22 +2,77 @@ package org.packman.packingList;
 
 import org.packman.category.Category;
 import org.packman.category.CategoryService;
+import org.packman.packingList.request.PackingListPosition;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
-@Transactional(readOnly = true)
 public class PackingListService {
+
+    private final PackingListRepository packingListRepository;
 
     private final CategoryService categoryService;
 
-    public PackingListService(CategoryService categoryService) {
+    public PackingListService(PackingListRepository packingListRepository, CategoryService categoryService) {
+        this.packingListRepository = packingListRepository;
         this.categoryService = categoryService;
     }
 
+    @Transactional(readOnly = true)
     public List<Category> getCategories(Long packingListId) {
         return categoryService.getAllByPackingListId(packingListId);
+    }
+
+    @Transactional
+    public void updatePosition(PackingListPosition packingListPosition) {
+        PackingList originalPackingList = packingListRepository.findById(packingListPosition.getId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 패킹리스트입니다."));
+
+        packingListOut(originalPackingList);
+
+        PackingList updatePackingList = originalPackingList.updatePosition(
+                packingListPosition.getPosition()
+        );
+
+        packingListIn(updatePackingList);
+    }
+
+    public void packingListOut(PackingList packingListBeforeMove) {
+        List<PackingList> packingLists = packingListRepository.findByPositionGreaterThan(
+                packingListBeforeMove.getPosition()
+        );
+
+        List<PackingList> updatedPackingLists = new ArrayList<>();
+
+        for (PackingList packingList : packingLists) {
+            PackingList updatePackingList = packingList.updatePosition(packingList.getPosition() - 1);
+            updatedPackingLists.add(updatePackingList);
+        }
+
+        PackingList originalPackingList = packingListBeforeMove.updatePosition(null);
+
+        updatedPackingLists.add(originalPackingList);
+
+        packingListRepository.saveAll(updatedPackingLists);
+    }
+
+    private void packingListIn(PackingList packingListAfterMove) {
+        List<PackingList> packingLists = packingListRepository.findByPositionGreaterThanEqual(
+                packingListAfterMove.getPosition()
+        );
+
+        List<PackingList> updatePacks = new ArrayList<>();
+
+        for (PackingList packingList : packingLists) {
+            PackingList updatePack = packingList.updatePosition(packingList.getPosition() + 1);
+            updatePacks.add(updatePack);
+        }
+
+        updatePacks.add(packingListAfterMove);
+
+        packingListRepository.saveAll(updatePacks);
     }
 }

--- a/src/main/java/org/packman/packingList/request/PackingListPosition.java
+++ b/src/main/java/org/packman/packingList/request/PackingListPosition.java
@@ -1,0 +1,16 @@
+package org.packman.packingList.request;
+
+public class PackingListPosition {
+
+    private Long id;
+
+    private int position;
+
+    public Long getId() {
+        return id;
+    }
+
+    public int getPosition() {
+        return position;
+    }
+}


### PR DESCRIPTION
## ✅ 한 일 
- 패킹리스트 순서 변경 API 구현

## 📝 구현 설명 및 결과

기존에 구현했었던 짐 순서 변경 API와 거의 동일하게 구현

## 😊 마무리
- close #9 